### PR TITLE
Fix paths for version 8.7.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ For developers: http://barrydegraaff.github.io/OpenPGPZimletJSDoc/OpenPGPZimlet.
 
     [root@myzimbra ~]# rm -Rf /opt/zimbra/zimlets-deployed/_dev/tk_barrydegraaff_zimbra_openpgp/
     [root@myzimbra ~]# su zimbra       
-    [zimbra@myzimbra ~] wget https://github.com/Zimbra-Community/pgp-zimlet/releases/download/2.7.0/tk_barrydegraaff_zimbra_openpgp.zip -O /tmp/tk_barrydegraaff_zimbra_openpgp.zip
+    [zimbra@myzimbra ~] wget https://github.com/Zimbra-Community/pgp-zimlet/releases/download/2.7.1/tk_barrydegraaff_zimbra_openpgp.zip -O /tmp/tk_barrydegraaff_zimbra_openpgp.zip
     [zimbra@myzimbra ~] zmzimletctl deploy /tmp/tk_barrydegraaff_zimbra_openpgp.zip
     [zimbra@myzimbra ~] zmmailboxdctl restart
 
@@ -49,7 +49,7 @@ Without translations support:
 ### `***UNCHECKED***` gets added to the subject of encrypted mail
 
     As root su to the root.
-    nano /opt/zimbra/amavisd/sbin/amavisd
+    nano /opt/zimbra/common/sbin/amavisd
     
     change the line:
     $undecipherable_subject_tag = '***UNCHECKED*** ';


### PR DESCRIPTION
download release 2.7.1 that fixes regression for zimbra 8.7.7.
also fix amavisd path for zimbra 8.7.7.